### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,12 +6,12 @@ Led	KEYWORD1
 DimmableLed	KEYWORD1
 Switch2Pos	KEYWORD1
 Switch3Pos	KEYWORD1
-SwitchMultiPos KEYWORD1
+SwitchMultiPos	KEYWORD1
 Potentiometer	KEYWORD1
 Stepper	KEYWORD1
 DirectInputPin	KEYWORD1
 DirectOutputPin	KEYWORD1
 DirectAnalogInput	KEYWORD1
 DirectAnalogOutput	KEYWORD1
-DirectStepperDriver KEYWORD1
-AcceleratedStepperOutput KEYWORD1
+DirectStepperDriver	KEYWORD1
+AcceleratedStepperOutput	KEYWORD1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords